### PR TITLE
Fixed: issue with config.toml and unit_hashes_folder

### DIFF
--- a/casper-tool.py
+++ b/casper-tool.py
@@ -442,8 +442,12 @@ def generate_node(known_addresses, obj, nodes_path, node_version, public_address
     storage_path = "/storage/{}".format(public_address)
     config["storage"]["path"] = storage_path
     config["network"]["gossip_interval"] = 120000
-    config["consensus"]["unit_hashes_folder"] = storage_path
-    # config["consensus"]["unit_hashes_folder"] = storage_path
+    try:
+        config["consensus"]["highway"]
+    except NameError:
+        config["consensus"]["unit_hashes_folder"] = storage_path
+    else:
+        config["consensus"]["highway"]["unit_hashes_folder"] = storage_path
     toml.dump(config, open(os.path.join(node_config_path, "config.toml", ), "w"))
 
 


### PR DESCRIPTION
***What does this change do?***

- Fixed: issue with config.toml file making entry for unit_hashes_folder

***Why is this change needed?***

- The unit_hashes_folder location within the config.toml file changed
from one version to another